### PR TITLE
Add shebang to bin script

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import fs from 'fs-extra';
 import { Octokit } from 'octokit';
 import _ora, { oraPromise } from 'ora';


### PR DESCRIPTION
This is necessary, otherwise the script will be started as a shell script, which obviously fails. See: https://docs.npmjs.com/cli/v9/configuring-npm/package-json#bin